### PR TITLE
Remove instruction incompatible with latest clang

### DIFF
--- a/rjit/src/ir/Ir.cpp
+++ b/rjit/src/ir/Ir.cpp
@@ -33,7 +33,7 @@ Pattern* Pattern::match(BasicBlock::iterator& i) {
     llvm::Instruction* ins = &*i;
     Pattern* rjitIns = Pattern::getIR(ins);
     assert(rjitIns->start() == ins);
-    while (&*i && &*i != rjitIns->end())
+    while (&*i != rjitIns->end())
         i++;
     assert(rjitIns->end() == &*i);
     ++i; // move to next instruction


### PR DESCRIPTION
With new Xcode and clang compiler, I have been hitting this error 

```
rjit/src/ir/Ir.cpp:36:13: error: reference cannot be bound to dereferenced null pointer in well-defined C++ code; pointer may be assumed to always convert to true [-Werror,-Wundefined-bool-conversion]
    while (&*i && &*i != rjitIns->end())
            ^~ ~~
/Users/romantsegelskyi/Code/llvm/llvm-src-370/include/llvm/ADT/ilist.h:199:13: note: 'operator*' returns a reference
  reference operator*() const {
            ^
1 error generated.
```

@o- Is it possible to just remove `NULL` check, since we are comparing it to `rjitIns->end()`, which is never `NULL`.

I found only one similar problem online, but that didn't help me much http://stackoverflow.com/questions/28689269/how-to-fix-reference-cannot-be-bound-to-dereferenced-null-pointer-warning
